### PR TITLE
Cache closed window

### DIFF
--- a/src/parent-controller.js
+++ b/src/parent-controller.js
@@ -1,33 +1,50 @@
 (function() {
     'use strict';
 
-    const config = {
-        'autoShow': true,
-        'minWidth': 918,
-        'minHeight': 510,
-        'defaultWidth': 1280,
-        'defaultHeight': 720,
-        'frame': false,
-        'url': 'index.html'
-    };
-    class ParentCtrl {
-        constructor($scope, windowCreationService) {
-            windowCreationService.ready(function() {
-                // TODO: Restore correct window(s)
-                windowCreationService.createMainWindow(config);
+    function getConfig() {
+        return {
+            'autoShow': true,
+            'minWidth': 918,
+            'minHeight': 510,
+            'defaultWidth': 1280,
+            'defaultHeight': 720,
+            'frame': false,
+            'url': 'index.html'
+        };
+    }
 
-                $scope.$on('updateFavourites', function(event, data) {
+    class ParentCtrl {
+        constructor($scope, storeService, windowCreationService) {
+            windowCreationService.ready(() => {
+                var previousWindows = storeService.getPreviousOpenWindowNames(),
+                    length = previousWindows.length,
+                    i,
+                    max;
+
+                if (length !== 0) {
+                    // Restoring previously open windows
+                    for (i = 0; i < length; i++) {
+                        var config = getConfig();
+                        config.name = previousWindows[i];
+                        windowCreationService.createMainWindow(config);
+                    }
+                } else {
+                    // Creating new window
+                    windowCreationService.createMainWindow(getConfig());
+                }
+
+                $scope.$on('updateFavourites', (event, data) => {
                     var e = new Event('updateFavourites');
                     e.stock = data;
                     var openWindows = windowCreationService.getWindows();
-                    for (var i = 0, max = openWindows.length; i < max; i++) {
+                    for (i = 0, max = openWindows.length; i < max; i++) {
                         openWindows[i].getNativeWindow().dispatchEvent(e);
                     }
                 });
             });
         }
     }
-    ParentCtrl.$inject = ['$scope', 'windowCreationService'];
+    ParentCtrl.$inject = ['$scope', 'storeService', 'windowCreationService'];
 
     angular.module('openfin.parent')
         .controller('ParentCtrl', ParentCtrl);

--- a/src/parent-controller.js
+++ b/src/parent-controller.js
@@ -14,9 +14,7 @@
         constructor($scope, windowCreationService) {
             windowCreationService.ready(function() {
                 // TODO: Restore correct window(s)
-                windowCreationService.createWindow(config, function(newWindow) {
-                    newWindow.show();
-                });
+                windowCreationService.createMainWindow(config);
 
                 $scope.$on('updateFavourites', function(event, data) {
                     var e = new Event('updateFavourites');

--- a/src/parentApp.js
+++ b/src/parentApp.js
@@ -5,7 +5,7 @@
         'openfin.parent'
     ]);
 
-    angular.module('openfin.parent', ['openfin.window']);
+    angular.module('openfin.parent', ['openfin.store', 'openfin.window']);
     angular.module('openfin.store', []);
     angular.module('openfin.currentWindow', []);
     angular.module('openfin.window', ['openfin.store']);

--- a/src/sidebars/favourites/tearout.js
+++ b/src/sidebars/favourites/tearout.js
@@ -217,10 +217,9 @@
 
                                         var config = createConfig(false, mainApplicationWindowPosition.width, mainApplicationWindowPosition.height);
 
-                                        windowService.createWindow(config, function(newWindow) {
+                                        windowService.createMainWindow(config, (newWindow) => {
                                             newWindow.moveTo(e.screenX, e.screenY);
                                             window.storeService.open(newWindow.name).add(scope.stock);
-                                            newWindow.show();
                                         });
 
                                         // Remove drop-target from original instance

--- a/src/store-service.js
+++ b/src/store-service.js
@@ -78,6 +78,12 @@
             this.storage = JSON.parse(localStorage.getItem(KEY_NAME)) || initialStocks;
         }
 
+        getPreviousOpenWindowNames() {
+            return this.storage
+                .filter((store) => !store.closed)
+                .map((store) => store.id);
+        }
+
         open(windowName) {
             var windowIndex = this.storage.map((window) => window.id)
                     .indexOf(windowName),

--- a/src/store-service.js
+++ b/src/store-service.js
@@ -1,16 +1,17 @@
 (function() {
     'use strict';
 
-    const KEY_NAME = 'windows';
-    const initialStocks = [
-        {
-            id: 'main',
-            stocks: [
-                'AAPL', 'MSFT', 'TITN', 'SNDK', 'TSLA'
-            ],
-            closed: 0
-        }
-    ];
+    const KEY_NAME = 'windows',
+        initialStocks = [
+            {
+                id: 'main',
+                stocks: [
+                    'AAPL', 'MSFT', 'TITN', 'SNDK', 'TSLA'
+                ],
+                closed: 0
+            }
+        ],
+        closedCacheSize = 5;
 
     class StoreWrapper {
         constructor($rootScope, storage, store) {
@@ -67,6 +68,24 @@
 
         closeWindow() {
             this.store.closed = Date.now();
+            this.save();
+
+            // Trim the oldest closed store
+            //
+            // TODO: This doesn't really belong here -- modifying the global storage object in a wrapper for
+            // a specific store doesn't seem correct
+            var closedArray = this.storage.filter((store) => store.closed !== 0);
+            if (closedArray.length > closedCacheSize) {
+                closedArray.sort((a, b) => {
+                    return b.closed - a.closed;
+                });
+
+                for (var i = closedCacheSize, max = closedArray.length; i < max; i++) {
+                    var storageIndex = this.storage.indexOf(closedArray[i]);
+                    this.storage.splice(storageIndex, 1);
+                }
+            }
+
             this.save();
         }
     }

--- a/src/store-service.js
+++ b/src/store-service.js
@@ -19,8 +19,12 @@
             this.store = store;
         }
 
-        save(stock) {
+        save() {
             localStorage.setItem(KEY_NAME, JSON.stringify(this.storage));
+        }
+
+        update(stock) {
+            this.save();
             this.$rootScope.$broadcast('updateFavourites', stock);
         }
 
@@ -39,7 +43,7 @@
             var toIndex = oldArray.indexOf(toItem);
             oldArray.splice(toIndex, 0, oldArray.splice(fromIndex, 1)[0]);
 
-            this.save();
+            this.update();
         }
 
         add(stock) {
@@ -47,7 +51,7 @@
 
             if (this.store.stocks.indexOf(stockName) === -1) {
                 this.store.stocks.push(stockName);
-                this.save(stock);
+                this.update(stock);
             }
         }
 
@@ -58,7 +62,12 @@
                 this.store.stocks.splice(index, 1);
             }
 
-            this.save(stock);
+            this.update(stock);
+        }
+
+        closeWindow() {
+            this.store.closed = true;
+            this.save();
         }
     }
 
@@ -67,7 +76,6 @@
             this.$rootScope = $rootScope;
 
             this.storage = JSON.parse(localStorage.getItem(KEY_NAME)) || initialStocks;
-            this.open.bind(this);
         }
 
         open(windowName) {

--- a/src/store-service.js
+++ b/src/store-service.js
@@ -8,7 +8,7 @@
             stocks: [
                 'AAPL', 'MSFT', 'TITN', 'SNDK', 'TSLA'
             ],
-            closed: false
+            closed: 0
         }
     ];
 
@@ -66,7 +66,7 @@
         }
 
         closeWindow() {
-            this.store.closed = true;
+            this.store.closed = Date.now();
             this.save();
         }
     }
@@ -80,7 +80,7 @@
 
         getPreviousOpenWindowNames() {
             return this.storage
-                .filter((store) => !store.closed)
+                .filter((store) => store.closed === 0)
                 .map((store) => store.id);
         }
 
@@ -95,7 +95,7 @@
                 var newStore = {
                     id: windowName,
                     stocks: [],
-                    closed: false
+                    closed: 0
                 };
 
                 // TODO: limit number of saved windows?

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -28,6 +28,10 @@
                 window.close();
             }
         }
+
+        count() {
+            return this.windowsOpen;
+        }
     }
 
     class WindowCreationService {
@@ -39,16 +43,18 @@
             this.apps = new AppManager();
         }
 
-        createWindow(config, successCb) {
+        createWindow(config, successCb, tearout) {
             config.name = getName();
             var newWindow = new fin.desktop.Window(config, () => {
                 this.windowsCache.push(newWindow);
 
-                // TODO
-                // Begin super hack
-                newWindow.getNativeWindow().windowService = this;
-                newWindow.getNativeWindow().storeService = this.storeService;
-                // End super hack
+                if (!tearout) {
+                    // TODO
+                    // Begin super hack
+                    newWindow.getNativeWindow().windowService = this;
+                    newWindow.getNativeWindow().storeService = this.storeService;
+                    // End super hack
+                }
 
                 if (successCb) {
                     successCb(newWindow);
@@ -68,6 +74,10 @@
                 var index = this.windowsCache.indexOf(newWindow);
                 this.windowsCache.slice(index, 1);
 
+                if (!tearout && this.apps.count() !== 1) {
+                    this.storeService.open(config.name).closeWindow();
+                }
+
                 this.apps.decrement();
             });
 
@@ -75,7 +85,7 @@
         }
 
         createTearoutWindow(config, parentName) {
-            var tearoutWindow = this.createWindow(config);
+            var tearoutWindow = this.createWindow(config, null, true);
 
             if (!this.openWindows[parentName]) {
                 this.openWindows[parentName] = [].concat(tearoutWindow);

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -1,108 +1,101 @@
 (function(fin) {
     'use strict';
+    var firstName = true;
+
+    function getName() {
+        if (firstName) {
+            firstName = false;
+            return 'main';
+        }
+
+        // TODO: Should probably change this...
+        return 'window' + Math.floor(Math.random() * 1000) + Math.ceil(Math.random() * 999);
+    }
+
+    class AppManager {
+        constructor() {
+            this.windowsOpen = 0;
+        }
+
+        increment() {
+            this.windowsOpen++;
+        }
+
+        decrement() {
+            this.windowsOpen--;
+
+            if (this.windowsOpen === 0) {
+                window.close();
+            }
+        }
+    }
+
+    class WindowCreationService {
+        constructor(storeService) {
+            this.storeService = storeService;
+            this.openWindows = {};
+            this.windowsCache = [];
+            this.firstName = true;
+            this.apps = new AppManager();
+        }
+
+        createWindow(config, successCb) {
+            config.name = getName();
+            var newWindow = new fin.desktop.Window(config, () => {
+                this.windowsCache.push(newWindow);
+
+                // TODO
+                // Begin super hack
+                newWindow.getNativeWindow().windowService = this;
+                newWindow.getNativeWindow().storeService = this.storeService;
+                // End super hack
+
+                if (successCb) {
+                    successCb(newWindow);
+                }
+            });
+
+            this.apps.increment();
+
+            newWindow.addEventListener('closed', (e) => {
+                var parent = this.openWindows[newWindow.name];
+                if (parent) {
+                    for (var i = 0, max = parent.length; i < max; i++) {
+                        parent[i].close();
+                    }
+                }
+
+                var index = this.windowsCache.indexOf(newWindow);
+                this.windowsCache.slice(index, 1);
+
+                this.apps.decrement();
+            });
+
+            return newWindow;
+        }
+
+        createTearoutWindow(config, parentName) {
+            var tearoutWindow = this.createWindow(config);
+
+            if (!this.openWindows[parentName]) {
+                this.openWindows[parentName] = [].concat(tearoutWindow);
+            } else {
+                this.openWindows[parentName].push(tearoutWindow);
+            }
+
+            return tearoutWindow;
+        }
+
+        ready(cb) {
+            fin.desktop.main(cb);
+        }
+
+        getWindows() {
+            return this.windowsCache;
+        }
+    }
+    WindowCreationService.$inject = ['storeService'];
 
     angular.module('openfin.window')
-        .factory('windowCreationService', ['storeService', function(storeService) {
-            var self = this;
-            var openWindows = {},
-                windowsCache = [],
-                firstName = true;
-
-            function appManager() {
-                var windowsOpen = 0;
-
-                function increment() {
-                    windowsOpen++;
-                }
-
-                function decrement() {
-                    windowsOpen--;
-
-                    if (windowsOpen === 0) {
-                        window.close();
-                    }
-                }
-
-                return {
-                    increment: increment,
-                    decrement: decrement
-                };
-            }
-
-            var apps = appManager();
-
-            function getName() {
-                if (firstName) {
-                    firstName = false;
-                    return 'main';
-                }
-
-                // TODO: Should probably change this...
-                return 'window' + Math.floor(Math.random() * 1000) + Math.ceil(Math.random() * 999);
-            }
-
-            self.createWindow = function(config, successCb) {
-                config.name = getName();
-                var newWindow = new fin.desktop.Window(config, function() {
-                    windowsCache.push(newWindow);
-
-                    // TODO
-                    // Begin super hack
-                    newWindow.getNativeWindow().windowService = self;
-                    newWindow.getNativeWindow().storeService = storeService;
-                    // End super hack
-
-                    if (successCb) {
-                        successCb(newWindow);
-                    }
-                });
-
-                apps.increment();
-
-                newWindow.addEventListener('closed', function(e) {
-                    var parent = openWindows[newWindow.name];
-                    if (parent) {
-                        for (var i = 0, max = parent.length; i < max; i++) {
-                            parent[i].close();
-                        }
-                    }
-
-                    apps.decrement();
-
-                    var index = windowsCache.indexOf(newWindow);
-                    windowsCache.slice(index, 1);
-
-                    // TODO: Need to set window's closed state to true in the store.
-                });
-
-                return newWindow;
-            };
-
-            self.createTearoutWindow = function(config, parentName) {
-                var tearoutWindow = self.createWindow(config);
-
-                if (!openWindows[parentName]) {
-                    openWindows[parentName] = [].concat(tearoutWindow);
-                } else {
-                    openWindows[parentName].push(tearoutWindow);
-                }
-
-                return tearoutWindow;
-            };
-
-            function ready(cb) {
-                fin.desktop.main(cb);
-            }
-
-            function getWindows() {
-                return windowsCache;
-            }
-
-            return {
-                createWindow: self.createWindow,
-                createTearoutWindow: self.createTearoutWindow,
-                ready: ready,
-                getWindows: getWindows
-            };
-        }]);
+        .service('windowCreationService', WindowCreationService);
 }(fin));

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -44,7 +44,10 @@
         }
 
         _createWindow(config, successCb, closedCb) {
-            config.name = getName();
+            if (!config.name) {
+                config.name = getName();
+            }
+
             var newWindow = new fin.desktop.Window(config, () => {
                 this.windowsCache.push(newWindow);
 


### PR DESCRIPTION
The first commit updates the windowService to a more ES6 compliant style. The second one updates the `closed` variable for each window in the local storage, except for the final window which stays with `closed: false`.

I'm interested particularly in feedback for the `createWindow` and `createTearoutWindow` methods, as I'm not currently too happy with the responsibility and boundaries between the two.