### PR TITLE
Fix chart shrinking issue

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE HTML>
+﻿﻿<!DOCTYPE HTML>
 <html lang="en" ng-app="OpenFinD3FC">
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
Award for the weirdest PR of the year. Adds in a `<U+FEFF>` byte order mark that somehow stops the chart shrinking issue.