### PR TITLE
Window pool

### DIFF
--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -11,6 +11,7 @@
         "document": true,
         "confirm": true,
         "Event": true,
-        "localStorage":  true
+        "localStorage": true,
+        "$q": true
     }
 }

--- a/src/sidebars/favourites/tearout.js
+++ b/src/sidebars/favourites/tearout.js
@@ -14,12 +14,8 @@
                             tileHeight = tearElement.clientHeight,
                             store;
 
-                        function createConfig(tearout, width, height) {
+                        function createConfig(tearout) {
                             var config = {
-                                'defaultWidth': tileWidth,
-                                'defaultHeight': tileHeight,
-                                'width': width,
-                                'height': height,
                                 'autoShow': false,
                                 'frame': false
                             };
@@ -43,7 +39,9 @@
                             return config;
                         }
 
-                        var tearoutWindowConfig = createConfig(true, tileWidth, tileHeight);
+                        var tearoutWindowConfig = createConfig(true);
+                        tearoutWindowConfig.height = tileHeight;
+                        tearoutWindowConfig.width = tileWidth;
 
                         var windowService = window.windowService;
                         var tearoutWindow = windowService.createTearoutWindow(tearoutWindowConfig, window.name);
@@ -215,9 +213,10 @@
                                         // Create new window instance
                                         var mainApplicationWindowPosition = getWindowPosition(window);
 
-                                        var config = createConfig(false, mainApplicationWindowPosition.width, mainApplicationWindowPosition.height);
+                                        var config = createConfig(false);
 
                                         windowService.createMainWindow(config, (newWindow) => {
+                                            newWindow.resizeTo(mainApplicationWindowPosition.width, mainApplicationWindowPosition.height, 'top-left');
                                             newWindow.moveTo(e.screenX, e.screenY);
                                             window.storeService.open(newWindow.name).add(scope.stock);
                                         });

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -6,6 +6,46 @@
         return 'window' + Math.floor(Math.random() * 1000) + Math.ceil(Math.random() * 999);
     }
 
+    function createConfig() {
+        return {
+            'name': getName(),
+            'autoShow': false,
+            'frame': false,
+            'resizable': true,
+            'maximizable': true,
+            'showTaskbarIcon': true,
+            'saveWindowState': true,
+            'minWidth': 918,
+            'minHeight': 510,
+            'url': 'index.html'
+        };
+    }
+
+    const poolSize = 3;
+
+    class FreeWindowPool {
+        constructor($q) {
+            this.pool = [];
+            this.$q = $q;
+
+            for (var i = 0; i < poolSize; i++) {
+                this._fillPool();
+            }
+        }
+
+        _fillPool() {
+            var deferred = this.$q.defer();
+            this.pool.push({ promise: deferred.promise, window: new fin.desktop.Window(createConfig(), () => { deferred.resolve(); }) });
+        }
+
+        fetch() {
+            var pooledWindow = this.pool.shift();
+            this._fillPool();
+
+            return pooledWindow;
+        }
+    }
+
     class AppManager {
         constructor() {
             this.windowsOpen = 0;
@@ -29,12 +69,15 @@
     }
 
     class WindowCreationService {
-        constructor(storeService) {
+        constructor(storeService, $q) {
             this.storeService = storeService;
             this.openWindows = {};
             this.windowsCache = [];
             this.firstName = true;
             this.apps = new AppManager();
+            this.pool = null;
+
+            this.ready(() => { this.pool = new FreeWindowPool($q); });
         }
 
         _addWindowClosedListener(_window, closedCb) {
@@ -97,8 +140,17 @@
             if (config.name) {
                 this._createWindow(config, windowCreatedCb, windowClosedCb);
             } else {
-                config.name = getName();
-                this._createWindow(config, windowCreatedCb, windowClosedCb);
+                this.ready(() => {
+                    var poolWindow = this.pool.fetch();
+                    this.windowsCache.push(poolWindow.window);
+                    poolWindow.promise.then(() => {
+                        windowCreatedCb(poolWindow.window);
+                    });
+
+                    this.apps.increment();
+
+                    this._addWindowClosedListener(poolWindow.window, windowClosedCb);
+                });
             }
         }
 
@@ -126,7 +178,7 @@
             return this.windowsCache;
         }
     }
-    WindowCreationService.$inject = ['storeService'];
+    WindowCreationService.$inject = ['storeService', '$q'];
 
     angular.module('openfin.window')
         .service('windowCreationService', WindowCreationService);


### PR DESCRIPTION
Implements a cache of ready OpenFin windows to increase usability and performance for tearing out favourite cards into new windows. Only main application windows are pooled -- windows for tearout cards are still handled as they were before.