### PR TITLE
Tear in

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -175,7 +175,7 @@ module.exports = function(grunt) {
                 dest: 'public/app.js'
             },
             parent: {
-                src: ['src/parentApp.js', 'src/parent-controller.js', 'src/store-service.js', 'src/window-service.js'],
+                src: ['src/parentApp.js', 'src/parent-controller.js', 'src/store-service.js', 'src/window-service.js', 'src/sidebars/favourites/geometry-service.js'],
                 dest: 'public/app-parent.js'
             }
         },

--- a/src/parentApp.js
+++ b/src/parentApp.js
@@ -8,5 +8,5 @@
     angular.module('openfin.parent', ['openfin.store', 'openfin.window']);
     angular.module('openfin.store', []);
     angular.module('openfin.currentWindow', []);
-    angular.module('openfin.window', ['openfin.store']);
+    angular.module('openfin.window', ['openfin.store', 'openfin.geometry']);
 }());

--- a/src/sidebars/favourites/geometry-service.js
+++ b/src/sidebars/favourites/geometry-service.js
@@ -49,12 +49,38 @@
     }
 
     class GeometryService {
-        constructor() {
-
-        }
-
         rectangle(arg) {
             return new Rectangle(arg);
+        }
+
+        // Helper function to retrieve the height, width, top, and left from a window object
+        getWindowPosition(windowElement) {
+            return {
+                height: windowElement.outerHeight,
+                width: windowElement.outerWidth,
+                top: windowElement.screenY,
+                left: windowElement.screenX
+            };
+        }
+
+        // Calculate the screen position of an element
+        elementScreenPosition(windowElement, element) {
+            var relativeElementPosition = element.getBoundingClientRect();
+
+            return {
+                height: relativeElementPosition.height,
+                width: relativeElementPosition.width,
+                top: windowElement.top + relativeElementPosition.top,
+                left: windowElement.left + relativeElementPosition.left
+            };
+        }
+
+        windowsIntersect(openFinWindow, _window) {
+            var nativeWindow1 = openFinWindow.getNativeWindow(),
+                rectangle1 = this.rectangle(this.getWindowPosition(nativeWindow1)),
+                rectangle2 = this.rectangle(this.getWindowPosition(_window));
+
+            return rectangle1.intersects(rectangle2);
         }
     }
 

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -69,8 +69,9 @@
     }
 
     class WindowCreationService {
-        constructor(storeService, $q) {
+        constructor(storeService, geometryService, $q) {
             this.storeService = storeService;
+            this.geometryService = geometryService;
             this.openWindows = {};
             this.windowsCache = [];
             this.firstName = true;
@@ -178,7 +179,7 @@
             return this.windowsCache;
         }
     }
-    WindowCreationService.$inject = ['storeService', '$q'];
+    WindowCreationService.$inject = ['storeService', 'geometryService', '$q'];
 
     angular.module('openfin.window')
         .service('windowCreationService', WindowCreationService);

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -70,9 +70,7 @@
             var parent = this.openWindows[_window.name];
             if (parent) {
                 // Close all the OpenFin tearout windows associated with the closing parent.
-                for (var i = 0, max = parent.length; i < max; i++) {
-                    parent[i].close();
-                }
+                parent.forEach((child) => child.close());
             }
 
             if (this.windowsOpen !== 1) {

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -95,6 +95,34 @@
         }
     }
 
+    class DragService {
+        constructor(storeService, geometryService, windowTracker, tearoutWindow) {
+            this.storeService = storeService;
+            this.geometryService = geometryService;
+            this.windowTracker = windowTracker;
+            this.tearoutWindow = tearoutWindow;
+            this.otherInstance = null;
+        }
+
+        overAnotherInstance() {
+            var mainWindows = this.windowTracker.getMainWindows();
+
+            for (var i = 0, max = mainWindows.length; i < max; i++) {
+                var mainWindow = mainWindows[i];
+                if (this.geometryService.windowsIntersect(this.tearoutWindow, mainWindow.getNativeWindow())) {
+                    this.otherInstance = mainWindow;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        moveToOtherInstance(stock) {
+            this.storeService.open(this.otherInstance.name).add(stock);
+        }
+    }
+
     class WindowCreationService {
         constructor(storeService, geometryService, $q) {
             this.storeService = storeService;
@@ -161,6 +189,10 @@
 
         getWindows() {
             return this.windowTracker.getMainWindows();
+        }
+
+        registerDrag(tearoutWindow) {
+            return new DragService(this.storeService, this.geometryService, this.windowTracker, tearoutWindow);
         }
     }
     WindowCreationService.$inject = ['storeService', 'geometryService', '$q'];

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -46,25 +46,52 @@
         }
     }
 
-    class AppManager {
+    class WindowTracker {
         constructor() {
+            this.openWindows = {};
+            this.mainWindowsCache = [];
             this.windowsOpen = 0;
         }
 
-        increment() {
+        add(_window) {
+            this.mainWindowsCache.push(_window);
             this.windowsOpen++;
         }
 
-        decrement() {
+        addTearout(name, _window) {
+            if (!this.openWindows[name]) {
+                this.openWindows[name] = [].concat(_window);
+            } else {
+                this.openWindows[name].push(_window);
+            }
+        }
+
+        dispose(_window, closedCb) {
+            var parent = this.openWindows[_window.name];
+            if (parent) {
+                // Close all the OpenFin tearout windows associated with the closing parent.
+                for (var i = 0, max = parent.length; i < max; i++) {
+                    parent[i].close();
+                }
+            }
+
+            if (this.windowsOpen !== 1) {
+                closedCb();
+            }
+
+            var index = this.mainWindowsCache.indexOf(_window);
+            this.mainWindowsCache.slice(index, 1);
+
             this.windowsOpen--;
 
             if (this.windowsOpen === 0) {
+                // This was the last open window; close the application.
                 window.close();
             }
         }
 
-        count() {
-            return this.windowsOpen;
+        getMainWindows() {
+            return this.mainWindowsCache;
         }
     }
 
@@ -72,49 +99,11 @@
         constructor(storeService, geometryService, $q) {
             this.storeService = storeService;
             this.geometryService = geometryService;
-            this.openWindows = {};
-            this.windowsCache = [];
+            this.windowTracker = new WindowTracker();
             this.firstName = true;
-            this.apps = new AppManager();
             this.pool = null;
 
             this.ready(() => { this.pool = new FreeWindowPool($q); });
-        }
-
-        _addWindowClosedListener(_window, closedCb) {
-            _window.addEventListener('closed', (e) => {
-                var parent = this.openWindows[_window.name];
-                if (parent) {
-                    for (var i = 0, max = parent.length; i < max; i++) {
-                        parent[i].close();
-                    }
-                }
-
-                var index = this.windowsCache.indexOf(_window);
-                this.windowsCache.slice(index, 1);
-
-                if (closedCb) {
-                    closedCb();
-                }
-
-                this.apps.decrement();
-            });
-        }
-
-        _createWindow(config, successCb, closedCb) {
-            var newWindow = new fin.desktop.Window(config, () => {
-                this.windowsCache.push(newWindow);
-
-                if (successCb) {
-                    successCb(newWindow);
-                }
-            });
-
-            this.apps.increment();
-
-            this._addWindowClosedListener(newWindow, closedCb);
-
-            return newWindow;
         }
 
         createMainWindow(config, successCb) {
@@ -125,6 +114,8 @@
                 newWindow.getNativeWindow().storeService = this.storeService;
                 // End super hack
 
+                this.windowTracker.add(newWindow);
+
                 if (successCb) {
                     successCb(newWindow);
                 }
@@ -132,27 +123,24 @@
                 newWindow.show();
             };
 
-            var windowClosedCb = () => {
-                if (this.apps.count() !== 1) {
-                    this.storeService.open(config.name).closeWindow();
-                }
-            };
-
+            var mainWindow;
             if (config.name) {
-                this._createWindow(config, windowCreatedCb, windowClosedCb);
+                mainWindow = new fin.desktop.Window(config, () => {
+                    windowCreatedCb(mainWindow);
+                });
             } else {
-                this.ready(() => {
-                    var poolWindow = this.pool.fetch();
-                    this.windowsCache.push(poolWindow.window);
-                    poolWindow.promise.then(() => {
-                        windowCreatedCb(poolWindow.window);
-                    });
-
-                    this.apps.increment();
-
-                    this._addWindowClosedListener(poolWindow.window, windowClosedCb);
+                var poolWindow = this.pool.fetch();
+                mainWindow = poolWindow.window;
+                poolWindow.promise.then(() => {
+                    windowCreatedCb(mainWindow);
                 });
             }
+
+            mainWindow.addEventListener('closed', (e) => {
+                this.windowTracker.dispose(mainWindow, () => {
+                    this.storeService.open(mainWindow.name).closeWindow();
+                });
+            });
         }
 
         createTearoutWindow(config, parentName) {
@@ -160,13 +148,9 @@
                 config.name = getName();
             }
 
-            var tearoutWindow = this._createWindow(config);
+            var tearoutWindow = new fin.desktop.Window(config);
 
-            if (!this.openWindows[parentName]) {
-                this.openWindows[parentName] = [].concat(tearoutWindow);
-            } else {
-                this.openWindows[parentName].push(tearoutWindow);
-            }
+            this.windowTracker.addTearout(parentName, tearoutWindow);
 
             return tearoutWindow;
         }
@@ -176,7 +160,7 @@
         }
 
         getWindows() {
-            return this.windowsCache;
+            return this.windowTracker.getMainWindows();
         }
     }
     WindowCreationService.$inject = ['storeService', 'geometryService', '$q'];


### PR DESCRIPTION
Refactor the window service so that the tearout windows are no longer tracked, so update events won't be pushed to them. Also moves some code into the geometry service, which is now shared with the parent app.