### PR TITLE
Persist compact view across runs

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -18,7 +18,7 @@
         'openfin.scroll'
     ]);
 
-    angular.module('openfin.main', ['openfin.currentWindow']);
+    angular.module('openfin.main', []);
     angular.module('openfin.showcase', ['openfin.selection', 'openfin.quandl']);
     angular.module('openfin.toolbar', ['openfin.currentWindow']);
     angular.module('openfin.icon', []);

--- a/src/main/main-controller.js
+++ b/src/main/main-controller.js
@@ -2,16 +2,19 @@
     'use strict';
 
     class MainCtrl {
-      constructor($timeout, currentWindowService) {
-          this.$timeout = $timeout;
-          this.currentWindowService = currentWindowService;
-      }
+        constructor() {
+            this.store = null;
+        }
 
-      isCompact() {
-          return this.currentWindowService.compact;
-      }
+        isCompact() {
+            if (!this.store && window.storeService) {
+                this.store = window.storeService.open(window.name);
+            }
+
+            return this.store && this.store.isCompact();
+        }
     }
-    MainCtrl.$inject = ['$timeout', 'currentWindowService'];
+    MainCtrl.$inject = [];
 
     angular.module('openfin.main')
         .controller('MainCtrl', MainCtrl);

--- a/src/parent-controller.js
+++ b/src/parent-controller.js
@@ -13,7 +13,7 @@
                     // Restoring previously open windows
                     for (i = 0; i < length; i++) {
                         var name = previousWindows[i];
-                        windowCreationService.createMainWindow(name);
+                        windowCreationService.createMainWindow(name, storeService.open(name).isCompact());
                     }
                 } else {
                     // Creating new window

--- a/src/sidebars/favourites/tearout.js
+++ b/src/sidebars/favourites/tearout.js
@@ -170,7 +170,7 @@
                                                 // Create new window instance
                                                 var mainApplicationWindowPosition = geometryService.getWindowPosition(window);
 
-                                                windowService.createMainWindow(null, (newWindow) => {
+                                                windowService.createMainWindow(null, store.isCompact(), (newWindow) => {
                                                     newWindow.resizeTo(mainApplicationWindowPosition.width, mainApplicationWindowPosition.height, 'top-left');
                                                     newWindow.moveTo(e.screenX, e.screenY);
                                                     window.storeService.open(newWindow.name).add(scope.stock);

--- a/src/sidebars/sidebar.html
+++ b/src/sidebars/sidebar.html
@@ -1,4 +1,4 @@
-<div class="sidebars" ng-class="{compact: sidebarCtrl.isCompact()}">
+<div class="sidebars">
     <div class="favourites {{sidebarCtrl.favouritesClass()}}" ng-controller="FavouritesCtrl as favouritesCtrl" ng-click="sidebarCtrl.favouritesClick()">
         <div class="sidetab-top">
             <img src="assets/svg/favourite_TOP.svg" class="top-icon" />

--- a/src/store-service.js
+++ b/src/store-service.js
@@ -63,6 +63,10 @@
             this.save();
         }
 
+        isCompact() {
+            return this.store.compact;
+        }
+
         closeWindow() {
             this.store.closed = Date.now();
             this.save();

--- a/src/toolbar/toolbar-controller.js
+++ b/src/toolbar/toolbar-controller.js
@@ -13,24 +13,21 @@
         }
 
         onReady() {
+            if (!this.store && window.storeService) {
+                this.store = window.storeService.open(window.name);
+            }
+
+            this.compact = this.store && this.store.isCompact();
             this.window = this.currentWindowService.getCurrentWindow();
-            this.window.getBounds((bounds) => {
-                this.compact = this.currentWindowService.compact = bounds.width === 230;
-            });
             this.window.addEventListener('maximized', () => {
                 this.$timeout(() => {
                     this.maximised = true;
                 });
-
-                this.window.addEventListener('restored', function(e) {
-                    this.$timeout(function() {
-                        this.maximised = false;
-                    });
-                });
             });
-            this.window.addEventListener('bounds-changed', (e) => {
-                this.window.getBounds((bounds) => {
-                    this.currentWindowService.compact = bounds.width === 230;
+
+            this.window.addEventListener('restored', () => {
+                this.$timeout(() => {
+                    this.maximised = false;
                 });
             });
         }
@@ -54,9 +51,9 @@
             }
 
             this.compact = !this.compact;
-            this.currentWindowService.compact = this.compact;
             this.store.toggleCompact(this.compact);
             window.windowService.updateOptions(this.window, this.compact);
+
             if (this.compact) {
                 this.window.resizeTo(230, 500, 'top-right');
             }

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -6,7 +6,7 @@
         return 'window' + Math.floor(Math.random() * 1000) + Math.ceil(Math.random() * 999);
     }
 
-    function createConfig(name) {
+    function createConfig(name, isCompact) {
         var config = {};
 
         config.name = name || getName();
@@ -15,14 +15,26 @@
         config.showTaskbarIcon = true;
         config.saveWindowState = true;
         config.url = 'index.html';
-        config.resizable = true;
-        config.maximizable = true;
-        config.minWidth = 918;
-        config.minHeight = 510;
-        config.maxWidth = 50000;
-        config.maxHeight = 50000;
-        config.defaultWidth = 1280;
-        config.defaultHeight = 720;
+
+        if (isCompact) {
+            config.resizable = false;
+            config.maximizable = false;
+            config.minWidth = 230;
+            config.minHeight = 500;
+            config.maxWidth = 230;
+            config.maxHeight = 500;
+            config.defaultWidth = 230;
+            config.defaultHeight = 500;
+        } else {
+            config.resizable = true;
+            config.maximizable = true;
+            config.minWidth = 918;
+            config.minHeight = 510;
+            config.maxWidth = 50000;
+            config.maxHeight = 50000;
+            config.defaultWidth = 1280;
+            config.defaultHeight = 720;
+        }
 
         return config;
     }
@@ -163,7 +175,7 @@
             this.ready(() => { this.pool = new FreeWindowPool($q); });
         }
 
-        createMainWindow(name, successCb) {
+        createMainWindow(name, isCompact, successCb) {
             var windowCreatedCb = (newWindow) => {
                 // TODO
                 // Begin super hack
@@ -183,12 +195,17 @@
 
             var mainWindow;
             if (name) {
-                mainWindow = new fin.desktop.Window(createConfig(name), () => {
+                mainWindow = new fin.desktop.Window(createConfig(name, isCompact), () => {
                     windowCreatedCb(mainWindow);
                 });
             } else {
                 var poolWindow = this.pool.fetch();
                 mainWindow = poolWindow.window;
+                if (isCompact) {
+                    this.updateOptions(poolWindow.window, true);
+                    this.window.resizeTo(230, 500, 'top-right');
+                }
+
                 poolWindow.promise.then(() => {
                     windowCreatedCb(mainWindow);
                 });
@@ -207,6 +224,24 @@
             this.windowTracker.addTearout(parentName, tearoutWindow);
 
             return tearoutWindow;
+        }
+
+        updateOptions(_window, isCompact) {
+            if (isCompact) {
+                _window.updateOptions({
+                    resizable: false,
+                    minHeight: 500,
+                    minWidth: 230,
+                    maximizable: false
+                });
+            } else {
+                _window.updateOptions({
+                    resizable: true,
+                    minHeight: 510,
+                    minWidth: 918,
+                    maximizable: true
+                });
+            }
         }
 
         updateOptions(_window, isCompact) {


### PR DESCRIPTION
Restore all windows to their previous state, now including compact view. Note when the app is requesting the services off the `window` object they may not be there yet. Angular will notice when the services are present and update accordingly. (E.g., on the `mainCtrl` when checking whether the window should be compact the service may not be present. However, when it does arrive this will be noticed. On my machine I don't see any weird visual behaviour when starting the app so I hope it's fast enough).

Also fixes a small bug where restoring from maximised via a drag didn't change the icon from restore back to maximise (a `function()` instead of `() =>` oversight).