### PR TITLE
Tearout from favourites tab

### DIFF
--- a/src/sidebars/favourites/geometry-service.js
+++ b/src/sidebars/favourites/geometry-service.js
@@ -45,42 +45,50 @@
                 otherOrigin.x < this.corner().x &&
                 otherOrigin.y < this.corner().y;
         }
+    }
 
+    // Helper function to retrieve the height, width, top, and left from a window object
+    function getWindowPosition(windowElement) {
+        return {
+            height: windowElement.outerHeight,
+            width: windowElement.outerWidth,
+            top: windowElement.screenY,
+            left: windowElement.screenX
+        };
+    }
+
+    // Calculate the screen position of an element
+    function elementScreenPosition(windowElement, element) {
+        var relativeElementPosition = element.getBoundingClientRect();
+
+        return {
+            height: relativeElementPosition.height,
+            width: relativeElementPosition.width,
+            top: windowElement.top + relativeElementPosition.top,
+            left: windowElement.left + relativeElementPosition.left
+        };
+    }
+
+    function intersectHelper(bounds1, bounds2) {
+        var rectangle1 = new Rectangle(bounds1),
+            rectangle2 = new Rectangle(bounds2);
+
+        return rectangle1.intersects(rectangle2);
     }
 
     class GeometryService {
-        rectangle(arg) {
-            return new Rectangle(arg);
-        }
-
-        // Helper function to retrieve the height, width, top, and left from a window object
-        getWindowPosition(windowElement) {
-            return {
-                height: windowElement.outerHeight,
-                width: windowElement.outerWidth,
-                top: windowElement.screenY,
-                left: windowElement.screenX
-            };
-        }
-
-        // Calculate the screen position of an element
-        elementScreenPosition(windowElement, element) {
-            var relativeElementPosition = element.getBoundingClientRect();
-
-            return {
-                height: relativeElementPosition.height,
-                width: relativeElementPosition.width,
-                top: windowElement.top + relativeElementPosition.top,
-                left: windowElement.left + relativeElementPosition.left
-            };
-        }
-
         windowsIntersect(openFinWindow, _window) {
-            var nativeWindow1 = openFinWindow.getNativeWindow(),
-                rectangle1 = this.rectangle(this.getWindowPosition(nativeWindow1)),
-                rectangle2 = this.rectangle(this.getWindowPosition(_window));
+            var nativeWindow = openFinWindow.getNativeWindow();
 
-            return rectangle1.intersects(rectangle2);
+            return intersectHelper(getWindowPosition(nativeWindow), getWindowPosition(_window));
+        }
+
+        elementIntersect(openFinWindow, _window, element) {
+            var nativeWindow = openFinWindow.getNativeWindow();
+
+            return intersectHelper(
+                getWindowPosition(nativeWindow),
+                elementScreenPosition(getWindowPosition(_window), element));
         }
     }
 

--- a/src/sidebars/favourites/tearout.js
+++ b/src/sidebars/favourites/tearout.js
@@ -193,7 +193,8 @@
                                 var hoverTargets = hoverService.get();
 
                                 for (var i = 0, max = hoverTargets.length; i < max; i++) {
-                                    var overDropTarget = geometryService.elementIntersect(tearoutWindow, window, hoverTargets[i].hoverArea);
+                                    var overDropTarget = geometryService.elementIntersect(
+                                        tearoutWindow, window, hoverTargets[i].hoverArea);
 
                                     if (overDropTarget) {
                                         if (!store) {
@@ -208,7 +209,8 @@
 
                             me.boundsChangingEvent = () => {
                                 // Check if you are over a drop target by seeing if the tearout rectangle intersects the drop target
-                                insideFavouritesPane = geometryService.elementIntersect(tearoutWindow, window, document.getElementsByClassName('favourites')[0]);
+                                insideFavouritesPane = geometryService.elementIntersect(
+                                    tearoutWindow, window, document.getElementsByClassName('favourites')[0]);
 
                                 if (insideFavouritesPane) {
                                     reorderFavourites();

--- a/src/sidebars/favourites/tearout.js
+++ b/src/sidebars/favourites/tearout.js
@@ -24,7 +24,7 @@
                                 myHoverArea = parent.getElementsByClassName('hover-area')[0],
                                 offset = { x: 0, y: 0 },
                                 currentlyDragging = false,
-                                insideMainWindow = true,
+                                insideFavouritesPane = true,
                                 dragService;
 
                             hoverService.add(myHoverArea, scope.stock.code);
@@ -119,7 +119,7 @@
                                     return false;
                                 }
 
-                                dragService = windowService.registerDrag(tearoutWindow);
+                                dragService = windowService.registerDrag(tearoutWindow, currentWindowService.getCurrentWindow());
 
                                 me.setCurrentlyDragging(true)
                                     .setOffset(e.offsetX, e.offsetY)
@@ -151,7 +151,7 @@
 
                                 if (currentlyDragging) {
                                     me.setCurrentlyDragging(false);
-                                    if (insideMainWindow) {
+                                    if (insideFavouritesPane) {
                                         me.returnFromTearout();
                                     } else {
                                         if (!store) {
@@ -167,11 +167,9 @@
                                                 dragService = null;
                                             } else {
                                                 // Create new window instance
-                                                var mainApplicationWindowPosition = geometryService.getWindowPosition(window);
-
                                                 var compact = store.isCompact();
                                                 windowService.createMainWindow(null, compact, (newWindow) => {
-                                                    newWindow.resizeTo(mainApplicationWindowPosition.width, mainApplicationWindowPosition.height, 'top-left');
+                                                    newWindow.resizeTo(window.outerWidth, window.outerHeight, 'top-left');
                                                     newWindow.moveTo(e.screenX, e.screenY);
                                                     var newStore = window.storeService.open(newWindow.name);
                                                     newStore.add(scope.stock);
@@ -191,13 +189,11 @@
                                 }
                             };
 
-                            function reorderFavourites(tearoutRectangle) {
+                            function reorderFavourites() {
                                 var hoverTargets = hoverService.get();
 
                                 for (var i = 0, max = hoverTargets.length; i < max; i++) {
-                                    var dropTargetRectangle = geometryService.rectangle(
-                                        geometryService.elementScreenPosition(geometryService.getWindowPosition(window), hoverTargets[i].hoverArea)),
-                                        overDropTarget = tearoutRectangle.intersects(dropTargetRectangle);
+                                    var overDropTarget = geometryService.elementIntersect(tearoutWindow, window, hoverTargets[i].hoverArea);
 
                                     if (overDropTarget) {
                                         if (!store) {
@@ -212,12 +208,10 @@
 
                             me.boundsChangingEvent = () => {
                                 // Check if you are over a drop target by seeing if the tearout rectangle intersects the drop target
-                                var nativeWindow = tearoutWindow.getNativeWindow(),
-                                    tearoutRectangle = geometryService.rectangle(geometryService.getWindowPosition(nativeWindow));
-                                insideMainWindow = geometryService.windowsIntersect(tearoutWindow, window);
+                                insideFavouritesPane = geometryService.elementIntersect(tearoutWindow, window, document.getElementsByClassName('favourites')[0]);
 
-                                if (insideMainWindow) {
-                                    reorderFavourites(tearoutRectangle);
+                                if (insideFavouritesPane) {
+                                    reorderFavourites();
                                 }
                             };
 

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -78,12 +78,13 @@
     }
 
     class DragService {
-        constructor(storeService, geometryService, windowTracker, tearoutWindow, $q) {
+        constructor(storeService, geometryService, windowTracker, tearoutWindow, $q, openFinWindow) {
             this.storeService = storeService;
             this.geometryService = geometryService;
             this.windowTracker = windowTracker;
             this.tearoutWindow = tearoutWindow;
             this.$q = $q;
+            this.openFinWindow = openFinWindow;
             this.otherInstance = null;
         }
 
@@ -92,7 +93,8 @@
                 result = false,
                 promises = [];
 
-            mainWindows.forEach((mainWindow) => {
+            var filteredWindows = mainWindows.filter((mw) => mw.name !== this.openFinWindow.name);
+            filteredWindows.forEach((mainWindow) => {
                 var deferred = this.$q.defer();
                 promises.push(deferred.promise);
                 mainWindow.getState((state) => {
@@ -229,8 +231,8 @@
             return this.windowTracker.getMainWindows().filter((w) => w.name === name)[0];
         }
 
-        registerDrag(tearoutWindow) {
-            return new DragService(this.storeService, this.geometryService, this.windowTracker, tearoutWindow, this.$q);
+        registerDrag(tearoutWindow, openFinWindow) {
+            return new DragService(this.storeService, this.geometryService, this.windowTracker, tearoutWindow, this.$q, openFinWindow);
         }
     }
     WindowCreationService.$inject = ['storeService', 'geometryService', '$q', 'configService'];

--- a/src/window-service.js
+++ b/src/window-service.js
@@ -248,7 +248,13 @@
         }
 
         registerDrag(tearoutWindow, openFinWindow) {
-            return new DragService(this.storeService, this.geometryService, this.windowTracker, tearoutWindow, this.$q, openFinWindow);
+            return new DragService(
+                this.storeService,
+                this.geometryService,
+                this.windowTracker,
+                tearoutWindow,
+                this.$q,
+                openFinWindow);
         }
     }
     WindowCreationService.$inject = ['storeService', 'geometryService', '$q', 'configService'];


### PR DESCRIPTION
Dragging a card outside of the favourites tab and releasing will now create a new window. Note that tearing in still applies to the whole window. Perhaps it should be changed for symmetry too? #435