### PR TITLE
Remove the need to specify target on grunt dev

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,7 +1,7 @@
 /* jshint node: true*/
 'use strict';
 module.exports = function(grunt) {
-    var target = grunt.option('target') || 'http://scottlogic.github.io/bitflux-openfin',
+    var target = grunt.option('target') || 'http://localhost:5000',
         port = process.env.PORT || 5000;
 
     grunt.initConfig({


### PR DESCRIPTION
Reasoning for this change:

 - `grunt dev` used to run the server off of Github Pages.
 - The `target` variable set where to load the Openfin config, however the `createZip` task defines that by downloading from Openfin with the path as a GET parameter.

I might've missed something that's important, but I'm not too sure

Also aids #424 